### PR TITLE
Update community link for LocalLLMRussia to LLM Crew

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ See most active contributors on [hexlet-friends](https://friends.hexlet.io/).
     * [MoscowQA (telegram)](https://t.me/moscowqa): Московское сообщество QA (тестировщиков).
     * [Coffee&Code iOS | Moscow](https://t.me/+XzaQa0CXlLAzMTM6): Чат iOS-разработчиков Москвы.
     * [Coffee&Code Android | Moscow](https://t.me/+kOTAHr4tfuo0NGIy): Чат Android-разработчиков Москвы.
-    * [LocalLLM Russia](https://t.me/LocalLLaMARussia): Сообщество по локальным и облачным LLM.
+    * [LLM Crew](llmcrew.org): Русскоязычное инженерное сообщество людей, которые строят системы и инструменты вокруг LLM.
 * Майами
     * [Coffee&Code Mobile | Miami](https://t.me/+pfgm3KRoP5djODBi): Чат мобильных разработчиков Майами.
 * Мерсин


### PR DESCRIPTION
Replaced LocalLLM Russia community link with LLM Crew.