### PR TITLE
Заменить логотип на русский вордмарк из brand-assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ##
 <a href="https://hexlet.io/?utm_source=github&utm_medium=link&utm_campaign=hexlet-assets">
-    <img src="https://raw.githubusercontent.com/Hexlet/assets/master/images/hexlet_logo.svg" alt="Hexlet Ltd. logo" height="128">
+    <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/Hexlet/brand-assets/master/images/svg/hexlet_wordmark_white_rus.svg">
+        <img src="https://raw.githubusercontent.com/Hexlet/brand-assets/master/images/svg/hexlet_wordmark_primary_rus.svg" alt="Хекслет" height="64">
+    </picture>
 </a>
 
 Репозиторий создан и поддерживается командой и сообществом Хекслета — образовательного проекта. [Подробнее о Хекслете](https://hexlet.io/?utm_source=github&utm_medium=link&utm_campaign=ru-local-communities).


### PR DESCRIPTION
Старый логотип брался из `Hexlet/assets` и был языконезависимым знаком. Заменён на вордмарк «Хекслет» из [Hexlet/brand-assets](https://github.com/Hexlet/brand-assets) — актуальный русский бренд-ассет.

Добавлен `<picture>` с тёмной темой: на светлой рендерится `hexlet_wordmark_primary_rus.svg` (чёрный текст + синий ромб), на тёмной — `hexlet_wordmark_white_rus.svg` (белый текст + синий ромб). Старый логотип был сплошь чёрным и на тёмной теме GitHub практически не читался.

Обе ссылки проверены — отдают 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)